### PR TITLE
feat: add context indexing utilities and CLI support

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -37,6 +37,17 @@ import meow from "meow";
 import path from "path";
 import React from "react";
 import { getProviderDefaultModel } from "./utils/get-provider";
+import {
+  CONTEXT_INDEX_FILENAME,
+  getChunkContent,
+  indexContext,
+  loadContextIndex,
+  searchContextChunks,
+} from "./utils/context-index/index.js";
+import {
+  formatIndexStats,
+  formatShowMatches,
+} from "./utils/context-index/renderers.js";
 
 // Call this early so `tail -F "$TMPDIR/oai-codex/codex-cli-latest.log"` works
 // immediately. This must be run with DEBUG=1 for logging to work.
@@ -52,6 +63,8 @@ const cli = meow(
   Usage
     $ codex [options] <prompt>
     $ codex completion <bash|zsh|fish>
+    $ codex context index [--path <dir>] [--refresh <file>]
+    $ codex context show <symbol> [--path <dir>]
 
   Options
     -h, --help                      Show usage and exit
@@ -85,6 +98,8 @@ const cli = meow(
   Examples
     $ codex "Write and run a python program that prints ASCII art"
     $ codex -q "fix build issues"
+    $ codex context index --path ./src
+    $ codex context show handler
     $ codex completion bash
 `,
   {
@@ -148,6 +163,14 @@ const cli = meow(
           "Disable truncation of command stdout/stderr messages (show everything)",
         aliases: ["no-truncate"],
       },
+      path: {
+        type: "string",
+        description: "Root path to index when using the context subcommand",
+      },
+      refresh: {
+        type: "string",
+        description: "Force re-indexing of a specific file when indexing context",
+      },
       // Notification
       notify: {
         type: "boolean",
@@ -175,6 +198,86 @@ _codex_completion() {
   local cur
   cur="\${COMP_WORDS[COMP_CWORD]}"
   COMPREPLY=( $(compgen -o default -o filenames -- "\${cur}") )
+}
+
+if (cli.input[0] === "context") {
+  const sub = cli.input[1];
+  const contextRoot = path.resolve(cli.flags.path || process.cwd());
+  const refreshFlag = cli.flags.refresh;
+  const refreshPaths = refreshFlag ? [String(refreshFlag)] : [];
+
+  const runContextCommand = async () => {
+    if (sub === "index") {
+      const { stats, indexPath } = await indexContext({
+        rootPath: contextRoot,
+        refreshPaths,
+      });
+      // eslint-disable-next-line no-console
+      console.log(formatIndexStats(stats, indexPath));
+      return;
+    }
+
+    if (sub === "show") {
+      const filter = cli.input.slice(2).join(" ").trim();
+      if (!filter) {
+        throw new Error("Usage: codex context show <symbol>");
+      }
+
+      const index = await loadContextIndex(contextRoot);
+      if (!index) {
+        const indexPath = path.join(
+          contextRoot,
+          ".codex",
+          CONTEXT_INDEX_FILENAME,
+        );
+        throw new Error(
+          `Context index not found at ${indexPath}. Run 'codex context index' first.`,
+        );
+      }
+
+      const matches = searchContextChunks(index, filter);
+      if (matches.length === 0) {
+        // eslint-disable-next-line no-console
+        console.log(`No context chunks match "${filter}".`);
+        return;
+      }
+
+      const limit = Number(process.env["CODEX_CONTEXT_SHOW_LIMIT"] || 5);
+      const { lines, truncated } = await formatShowMatches(
+        matches,
+        contextRoot,
+        limit,
+      );
+      for (const line of lines) {
+        // eslint-disable-next-line no-console
+        console.log(line);
+      }
+
+      if (truncated) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `\n… ${matches.length - lines.length} more match(es) not shown. Refine the filter to narrow results.`,
+        );
+      }
+
+      return;
+    }
+
+    throw new Error("Unknown context subcommand. Use 'index' or 'show'.");
+  };
+
+  runContextCommand()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      // eslint-disable-next-line no-console
+      console.error(message);
+      process.exit(1);
+    });
+
+  return;
 }
 complete -F _codex_completion codex`,
     zsh: `# zsh completion for codex

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -45,6 +45,7 @@ export default function TerminalChatInput({
   onCompact,
   interruptAgent,
   active,
+  onContextCommand,
 }: {
   isNew: boolean;
   loading: boolean;
@@ -65,6 +66,7 @@ export default function TerminalChatInput({
   onCompact: () => void;
   interruptAgent: () => void;
   active: boolean;
+  onContextCommand?: (filter: string) => Promise<void>;
 }): React.ReactElement {
   const app = useApp();
   const [selectedSuggestion, setSelectedSuggestion] = useState<number>(0);
@@ -171,6 +173,31 @@ export default function TerminalChatInput({
       if (inputValue === "/compact") {
         setInput("");
         onCompact();
+        return;
+      }
+
+      if (inputValue.startsWith("/context")) {
+        setInput("");
+        const filter = inputValue.slice("/context".length).trim();
+        if (onContextCommand) {
+          await onContextCommand(filter);
+        } else {
+          setItems((prev) => [
+            ...prev,
+            {
+              id: `context-missing-${Date.now()}`,
+              type: "message",
+              role: "system",
+              content: [
+                {
+                  type: "input_text",
+                  text:
+                    "Context index is not available in this mode. Run 'codex context index' and restart the CLI.",
+                },
+              ],
+            } as ResponseItem,
+          ]);
+        }
         return;
       }
 

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -34,6 +34,12 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { inspect } from "util";
 
 import { getModelProvider } from "../../utils/get-provider";
+import {
+  getChunkContent as loadChunkContent,
+  loadContextIndex as loadStoredContextIndex,
+  searchContextChunks,
+  type ContextIndexData,
+} from "../../utils/context-index/index.js";
 
 type Props = {
   config: AppConfig;
@@ -115,6 +121,9 @@ export default function TerminalChat({
     initialApprovalPolicy,
   );
   const [thinkingSeconds, setThinkingSeconds] = useState(0);
+  const [contextIndex, setContextIndex] = useState<ContextIndexData | null>(
+    null,
+  );
   const handleCompact = async () => {
     setLoading(true);
     try {
@@ -408,6 +417,145 @@ export default function TerminalChat({
     [items, model],
   );
 
+  useEffect(() => {
+    (async () => {
+      try {
+        const index = await loadStoredContextIndex(process.cwd());
+        setContextIndex(index);
+      } catch (error) {
+        if (isLoggingEnabled()) {
+          log(`Failed to load context index: ${inspect(error)}`);
+        }
+        setContextIndex(null);
+      }
+    })();
+  }, []);
+
+  const handleContextCommand = React.useCallback(
+    async (rawFilter: string) => {
+      const filter = rawFilter.trim();
+      if (!filter) {
+        setItems((prev) => [
+          ...prev,
+          {
+            id: `context-empty-${Date.now()}`,
+            type: "message",
+            role: "system",
+            content: [
+              {
+                type: "input_text",
+                text: "Usage: /context <filter> to insert matching chunks from the local index.",
+              },
+            ],
+          } as ResponseItem,
+        ]);
+        return;
+      }
+
+      let index = contextIndex;
+      if (!index) {
+        index = await loadStoredContextIndex(process.cwd());
+        setContextIndex(index);
+      }
+
+      if (!index) {
+        setItems((prev) => [
+          ...prev,
+          {
+            id: `context-missing-${Date.now()}`,
+            type: "message",
+            role: "system",
+            content: [
+              {
+                type: "input_text",
+                text:
+                  "Context index not found. Run 'codex context index' in the repository root and try again.",
+              },
+            ],
+          } as ResponseItem,
+        ]);
+        return;
+      }
+
+      const matches = searchContextChunks(index, filter);
+      if (matches.length === 0) {
+        setItems((prev) => [
+          ...prev,
+          {
+            id: `context-none-${Date.now()}`,
+            type: "message",
+            role: "system",
+            content: [
+              {
+                type: "input_text",
+                text: `No context chunks match "${filter}".`,
+              },
+            ],
+          } as ResponseItem,
+        ]);
+        return;
+      }
+
+      const limit = Number(process.env["CODEX_CONTEXT_SHOW_LIMIT"] || 5);
+      const selected = matches.slice(0, limit);
+      const entries: Array<ResponseItem> = [];
+
+      entries.push({
+        id: `context-info-${Date.now()}`,
+        type: "message",
+        role: "system",
+        content: [
+          {
+            type: "input_text",
+            text: `Inserting ${selected.length} context chunk(s) for filter "${filter}".`,
+          },
+        ],
+      } as ResponseItem);
+
+      for (const match of selected) {
+        const summaryLine = match.summary
+          ? `Summary: ${match.summary}`
+          : undefined;
+        const snippet = await loadChunkContent(process.cwd(), match);
+        const parts = [
+          `Context: ${match.symbol} (${match.path}:${match.range.start.line}-${match.range.end.line})`,
+        ];
+        if (summaryLine) {
+          parts.push(summaryLine);
+        }
+        parts.push(snippet);
+        entries.push({
+          id: `context-chunk-${match.hash}-${Date.now()}`,
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: parts.join("\n\n"),
+            },
+          ],
+        } as ResponseItem);
+      }
+
+      if (matches.length > selected.length) {
+        entries.push({
+          id: `context-more-${Date.now()}`,
+          type: "message",
+          role: "system",
+          content: [
+            {
+              type: "input_text",
+              text: `... ${matches.length - selected.length} additional match(es) not inserted. Refine the filter to narrow results.`,
+            },
+          ],
+        } as ResponseItem);
+      }
+
+      setItems((prev) => [...prev, ...entries]);
+    },
+    [contextIndex, setItems],
+  );
+
   return (
     <Box flexDirection="column">
       <Box flexDirection="column">
@@ -461,6 +609,7 @@ export default function TerminalChat({
             openHelpOverlay={() => setOverlayMode("help")}
             onCompact={handleCompact}
             active={overlayMode === "none"}
+            onContextCommand={handleContextCommand}
             interruptAgent={() => {
               if (!agent) {
                 return;

--- a/codex-cli/src/utils/context-index/chunkers/fallback.ts
+++ b/codex-cli/src/utils/context-index/chunkers/fallback.ts
@@ -1,0 +1,84 @@
+import type { ChunkDescriptor } from "../types.js";
+
+const DEFAULT_CHUNK_SIZE = parseInt(
+  process.env["CODEX_CONTEXT_FALLBACK_CHARS"] || "2000",
+  10,
+);
+
+function createDescriptor(
+  symbol: string,
+  startOffset: number,
+  endOffset: number,
+  startLine: number,
+  endLine: number,
+): ChunkDescriptor {
+  return {
+    symbol,
+    range: {
+      start: { offset: startOffset, line: startLine, column: 1 },
+      end: { offset: endOffset, line: endLine, column: 1 },
+    },
+  };
+}
+
+export function fallbackChunk(
+  filePath: string,
+  sourceText: string,
+  chunkSize: number = DEFAULT_CHUNK_SIZE,
+): Array<ChunkDescriptor> {
+  if (chunkSize <= 0) {
+    chunkSize = DEFAULT_CHUNK_SIZE;
+  }
+
+  const descriptors: Array<ChunkDescriptor> = [];
+  let start = 0;
+  let chunkIndex = 0;
+  const totalLength = sourceText.length;
+
+  if (totalLength === 0) {
+    descriptors.push(createDescriptor(`${filePath}:empty`, 0, 0, 1, 1));
+    return descriptors;
+  }
+
+  const lineOffsets: Array<number> = [0];
+  for (let i = 0; i < totalLength; i += 1) {
+    if (sourceText[i] === "\n") {
+      lineOffsets.push(i + 1);
+    }
+  }
+  lineOffsets.push(totalLength);
+
+  const getLineForOffset = (offset: number): number => {
+    let low = 0;
+    let high = lineOffsets.length - 1;
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      const current = lineOffsets[mid] ?? 0;
+      if (current <= offset) {
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+    return Math.max(0, high) + 1;
+  };
+
+  while (start < totalLength) {
+    const end = Math.min(totalLength, start + chunkSize);
+    const startLine = getLineForOffset(start);
+    const endLine = getLineForOffset(end);
+    descriptors.push(
+      createDescriptor(
+        `${filePath}:chunk-${chunkIndex + 1}`,
+        start,
+        end,
+        startLine,
+        endLine,
+      ),
+    );
+    start = end;
+    chunkIndex += 1;
+  }
+
+  return descriptors;
+}

--- a/codex-cli/src/utils/context-index/chunkers/index.ts
+++ b/codex-cli/src/utils/context-index/chunkers/index.ts
@@ -1,0 +1,12 @@
+import { typescriptChunker } from "./typescript.js";
+import type { Chunker } from "../types.js";
+
+const REGISTERED_CHUNKERS: Array<Chunker> = [typescriptChunker];
+
+export function getChunkerForPath(filePath: string): Chunker | undefined {
+  return REGISTERED_CHUNKERS.find((chunker) => chunker.test(filePath));
+}
+
+export function registerChunker(chunker: Chunker): void {
+  REGISTERED_CHUNKERS.push(chunker);
+}

--- a/codex-cli/src/utils/context-index/chunkers/typescript.ts
+++ b/codex-cli/src/utils/context-index/chunkers/typescript.ts
@@ -1,0 +1,122 @@
+import ts from "typescript";
+import path from "node:path";
+
+import type { ChunkDescriptor, ChunkRange, Chunker } from "../types.js";
+
+function createRange(
+  sourceFile: ts.SourceFile,
+  start: number,
+  end: number,
+): ChunkRange {
+  const startPos = sourceFile.getLineAndCharacterOfPosition(start);
+  const endPos = sourceFile.getLineAndCharacterOfPosition(end);
+  return {
+    start: {
+      offset: start,
+      line: startPos.line + 1,
+      column: startPos.character + 1,
+    },
+    end: {
+      offset: end,
+      line: endPos.line + 1,
+      column: endPos.character + 1,
+    },
+  };
+}
+
+function extractSymbolName(node: ts.Node, sourceFile: ts.SourceFile): string | null {
+  if (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) {
+    return node.name?.getText(sourceFile) ?? null;
+  }
+
+  if (ts.isMethodDeclaration(node) || ts.isGetAccessor(node) || ts.isSetAccessor(node)) {
+    const classDecl = node.parent;
+    const className = ts.isClassLike(classDecl)
+      ? classDecl.name?.getText(sourceFile) ?? "anonymous-class"
+      : "anonymous-class";
+    const memberName = node.name?.getText(sourceFile) ?? "anonymous-member";
+    return `${className}.${memberName}`;
+  }
+
+  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+    // Attempt to find an identifier the function is assigned to.
+    if (
+      ts.isVariableDeclaration(node.parent) &&
+      node.parent.name &&
+      ts.isIdentifier(node.parent.name)
+    ) {
+      return node.parent.name.getText(sourceFile);
+    }
+
+    if (
+      ts.isBinaryExpression(node.parent) &&
+      node.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.parent.left)
+    ) {
+      return node.parent.left.getText(sourceFile);
+    }
+  }
+
+  if (ts.isInterfaceDeclaration(node) || ts.isTypeAliasDeclaration(node)) {
+    return node.name.getText(sourceFile);
+  }
+
+  return null;
+}
+
+function collectChunkDescriptors(
+  sourceFile: ts.SourceFile,
+): Array<ChunkDescriptor> {
+  const descriptors: Array<ChunkDescriptor> = [];
+  const visited = new Set<string>();
+
+  function pushDescriptor(node: ts.Node, symbolName: string) {
+    const start = node.getStart(sourceFile, false);
+    const end = node.getEnd();
+    const key = `${symbolName}:${start}:${end}`;
+    if (visited.has(key)) {
+      return;
+    }
+    visited.add(key);
+    descriptors.push({ symbol: symbolName, range: createRange(sourceFile, start, end) });
+  }
+
+  function visit(node: ts.Node) {
+    const symbol = extractSymbolName(node, sourceFile);
+    if (symbol) {
+      pushDescriptor(node, symbol);
+    }
+
+    node.forEachChild(visit);
+  }
+
+  visit(sourceFile);
+
+  descriptors.sort((a, b) => a.range.start.offset - b.range.start.offset);
+  return descriptors;
+}
+
+const SUPPORTED_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx"]);
+
+export const typescriptChunker: Chunker = {
+  test(filePath: string) {
+    return SUPPORTED_EXTENSIONS.has(path.extname(filePath));
+  },
+  extract(filePath: string, sourceText: string) {
+    const sourceFile = ts.createSourceFile(
+      filePath,
+      sourceText,
+      ts.ScriptTarget.Latest,
+      true,
+      path.extname(filePath) === ".tsx"
+        ? ts.ScriptKind.TSX
+        : path.extname(filePath) === ".jsx"
+          ? ts.ScriptKind.JSX
+          : ts.ScriptKind.TS,
+    );
+
+    return collectChunkDescriptors(sourceFile);
+  },
+};
+
+export default typescriptChunker;

--- a/codex-cli/src/utils/context-index/index.ts
+++ b/codex-cli/src/utils/context-index/index.ts
@@ -1,0 +1,288 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  loadIgnorePatterns,
+  shouldIgnorePath,
+} from "../singlepass/context_files.js";
+import { fallbackChunk } from "./chunkers/fallback.js";
+import { getChunkerForPath } from "./chunkers/index.js";
+import { buildMerkleTree, hashChunkContent } from "./merkle.js";
+import { SummaryCache } from "./summaries.js";
+import type {
+  ChunkDescriptor,
+  ContextChunk,
+  ContextIndexData,
+  FileIndexEntry,
+  IndexOptions,
+  IndexStats,
+  SearchMatch,
+} from "./types.js";
+
+const INDEX_VERSION = 1;
+export const CONTEXT_INDEX_FILENAME = "context-index.json";
+
+async function readIndexFile(filePath: string): Promise<ContextIndexData | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as ContextIndexData;
+    return parsed;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeIndexFile(
+  filePath: string,
+  data: ContextIndexData,
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+async function walkFiles(
+  dir: string,
+  ignorePatterns: Array<RegExp>,
+): Promise<Array<string>> {
+  const queue: Array<string> = [dir];
+  const files: Array<string> = [];
+
+  while (queue.length > 0) {
+    const current = queue.pop();
+    if (!current) {
+      continue;
+    }
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolute = path.join(current, entry.name);
+      if (shouldIgnorePath(absolute, ignorePatterns)) {
+        continue;
+      }
+      if (entry.isDirectory()) {
+        queue.push(absolute);
+      } else if (entry.isFile()) {
+        files.push(absolute);
+      }
+    }
+  }
+
+  files.sort();
+  return files;
+}
+
+function toRelative(rootPath: string, filePath: string): string {
+  const relative = path.relative(rootPath, filePath);
+  return relative || path.basename(filePath);
+}
+
+function normaliseRefreshPaths(
+  rootPath: string,
+  refreshPaths: Array<string> | undefined,
+): Set<string> {
+  if (!refreshPaths || refreshPaths.length === 0) {
+    return new Set();
+  }
+  return new Set(
+    refreshPaths.map((input) =>
+      path.relative(rootPath, path.resolve(rootPath, input)),
+    ),
+  );
+}
+
+function ensureChunks(
+  filePath: string,
+  content: string,
+  descriptors: Array<ChunkDescriptor>,
+  fallbackSize?: number,
+): Array<ChunkDescriptor> {
+  if (descriptors.length > 0) {
+    return descriptors;
+  }
+  return fallbackChunk(filePath, content, fallbackSize);
+}
+
+function sliceContent(content: string, start: number, end: number): string {
+  return content.slice(start, end);
+}
+
+function pruneSummaries(
+  data: Record<string, string>,
+  usedHashes: Set<string>,
+): Record<string, string> {
+  const pruned: Record<string, string> = {};
+  for (const [hash, summary] of Object.entries(data)) {
+    if (usedHashes.has(hash)) {
+      pruned[hash] = summary;
+    }
+  }
+  return pruned;
+}
+
+export async function loadContextIndex(
+  rootPath: string,
+): Promise<ContextIndexData | null> {
+  const resolvedRoot = path.resolve(rootPath);
+  const indexPath = path.join(resolvedRoot, ".codex", CONTEXT_INDEX_FILENAME);
+  const index = await readIndexFile(indexPath);
+  if (!index) {
+    return null;
+  }
+
+  // Fill in summaries on the chunk structures for convenience.
+  for (const entry of Object.values(index.files)) {
+    for (const chunk of entry.chunks) {
+      chunk.summary = index.summaries[chunk.hash];
+    }
+  }
+  return index;
+}
+
+export async function indexContext(
+  options: IndexOptions,
+): Promise<{
+  index: ContextIndexData;
+  stats: IndexStats;
+  indexPath: string;
+}> {
+  const rootPath = path.resolve(options.rootPath);
+  const targetPath = options.targetPath
+    ? path.resolve(rootPath, options.targetPath)
+    : rootPath;
+  const indexPath = path.join(rootPath, ".codex", CONTEXT_INDEX_FILENAME);
+  const ignorePatterns = loadIgnorePatterns();
+  const refreshSet = normaliseRefreshPaths(rootPath, options.refreshPaths);
+  const previousIndex = await readIndexFile(indexPath);
+  const summaryCache = new SummaryCache(
+    previousIndex?.summaries ?? {},
+    options.summaryGenerator,
+  );
+  const fallbackSize = options.fallbackChunkSize;
+
+  const absoluteFiles = await walkFiles(targetPath, ignorePatterns);
+  const files: Record<string, FileIndexEntry> = {};
+  let filesUpdated = 0;
+  let chunksDiscovered = 0;
+
+  for (const absolutePath of absoluteFiles) {
+    const relativePath = toRelative(rootPath, absolutePath);
+    const content = await fs.readFile(absolutePath, "utf-8");
+    const chunker = getChunkerForPath(absolutePath);
+    const descriptors = ensureChunks(
+      relativePath,
+      content,
+      chunker ? chunker.extract(absolutePath, content) : [],
+      fallbackSize,
+    );
+
+    const chunks: Array<ContextChunk> = descriptors.map((descriptor) => {
+      const chunk: ContextChunk = {
+        path: relativePath,
+        symbol: descriptor.symbol,
+        range: descriptor.range,
+        hash: "",
+      };
+      const chunkContent = sliceContent(
+        content,
+        descriptor.range.start.offset,
+        descriptor.range.end.offset,
+      );
+      chunk.hash = hashChunkContent(chunk, chunkContent);
+      return chunk;
+    });
+
+    const merkle = buildMerkleTree(chunks);
+    const previousEntry = previousIndex?.files[relativePath];
+    const refreshFile = refreshSet.has(relativePath);
+    if (!previousEntry || previousEntry.merkle.hash !== merkle.hash || refreshFile) {
+      filesUpdated += 1;
+    }
+
+    for (const chunk of chunks) {
+      const chunkContent = sliceContent(
+        content,
+        chunk.range.start.offset,
+        chunk.range.end.offset,
+      );
+      const summary = await summaryCache.ensureSummary(chunk, chunkContent, {
+        force: refreshFile,
+      });
+      chunk.summary = summary;
+    }
+
+    files[relativePath] = { path: relativePath, merkle, chunks };
+    chunksDiscovered += chunks.length;
+  }
+
+  const usedHashes = new Set<string>();
+  for (const entry of Object.values(files)) {
+    for (const chunk of entry.chunks) {
+      usedHashes.add(chunk.hash);
+    }
+  }
+
+  const index: ContextIndexData = {
+    version: INDEX_VERSION,
+    generatedAt: new Date().toISOString(),
+    files,
+    summaries: pruneSummaries(summaryCache.toJSON(), usedHashes),
+  };
+
+  await writeIndexFile(indexPath, index);
+
+  const stats: IndexStats = {
+    filesProcessed: absoluteFiles.length,
+    filesUpdated,
+    chunksDiscovered,
+    summariesGenerated: summaryCache.getGeneratedCount(),
+  };
+
+  return { index, stats, indexPath };
+}
+
+export function searchContextChunks(
+  index: ContextIndexData,
+  filter: string,
+): Array<SearchMatch> {
+  const normalized = filter.trim().toLowerCase();
+  if (!normalized) {
+    return [];
+  }
+
+  const matches: Array<SearchMatch> = [];
+  for (const entry of Object.values(index.files)) {
+    for (const chunk of entry.chunks) {
+      const haystack = `${chunk.symbol.toLowerCase()} ${chunk.path.toLowerCase()}`;
+      if (haystack.includes(normalized)) {
+        matches.push({
+          ...chunk,
+          summary: index.summaries[chunk.hash] ?? chunk.summary,
+          fileSummary: entry.merkle.hash,
+        });
+      }
+    }
+  }
+
+  matches.sort((a, b) => a.path.localeCompare(b.path));
+  return matches;
+}
+
+export async function getChunkContent(
+  rootPath: string,
+  chunk: ContextChunk,
+): Promise<string> {
+  const absolute = path.resolve(rootPath, chunk.path);
+  const content = await fs.readFile(absolute, "utf-8");
+  return sliceContent(content, chunk.range.start.offset, chunk.range.end.offset);
+}
+
+export type {
+  ContextChunk,
+  ContextIndexData,
+  FileIndexEntry,
+  IndexOptions,
+  IndexStats,
+  SearchMatch,
+} from "./types.js";

--- a/codex-cli/src/utils/context-index/merkle.ts
+++ b/codex-cli/src/utils/context-index/merkle.ts
@@ -1,0 +1,61 @@
+import { createHash } from "node:crypto";
+
+import type { ContextChunk, MerkleNode } from "./types.js";
+
+export function sha256(data: string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+export function hashChunkContent(
+  chunk: Pick<ContextChunk, "path" | "symbol" | "range">,
+  content: string,
+): string {
+  const key = [
+    chunk.path,
+    chunk.symbol,
+    `${chunk.range.start.offset}:${chunk.range.end.offset}`,
+    content,
+  ].join("|#|");
+  return sha256(key);
+}
+
+export function buildMerkleTree(chunks: Array<ContextChunk>): MerkleNode {
+  const leaves = chunks.map<MerkleNode>((chunk) => ({
+    hash: sha256(chunk.hash),
+    chunk,
+    children: [],
+  }));
+
+  if (leaves.length === 0) {
+    return { hash: sha256("empty"), children: [] };
+  }
+
+  let layer = leaves;
+  while (layer.length > 1) {
+    const nextLayer: Array<MerkleNode> = [];
+    for (let index = 0; index < layer.length; index += 2) {
+      const left = layer[index];
+      const right = layer[index + 1];
+      const combined = createHash("sha256");
+      combined.update(left.hash);
+      if (right) {
+        combined.update(right.hash);
+      }
+      const parent: MerkleNode = {
+        hash: combined.digest("hex"),
+        children: right ? [left, right] : [left],
+      };
+      nextLayer.push(parent);
+    }
+    layer = nextLayer;
+  }
+
+  return layer[0];
+}
+
+export function collectChunkHashes(node: MerkleNode): Array<string> {
+  if (node.chunk) {
+    return [node.chunk.hash];
+  }
+  return node.children.flatMap((child) => collectChunkHashes(child));
+}

--- a/codex-cli/src/utils/context-index/renderers.ts
+++ b/codex-cli/src/utils/context-index/renderers.ts
@@ -1,0 +1,25 @@
+import { getChunkContent } from "./index.js";
+import type { IndexStats, SearchMatch } from "./types.js";
+
+export function formatIndexStats(stats: IndexStats, indexPath: string): string {
+  return `Indexed ${stats.filesProcessed} file(s). Updated ${stats.filesUpdated}, discovered ${stats.chunksDiscovered} chunk(s), generated ${stats.summariesGenerated} new summar${
+    stats.summariesGenerated === 1 ? "y" : "ies"
+  }.\nContext index written to ${indexPath}`;
+}
+
+export async function formatShowMatches(
+  matches: Array<SearchMatch>,
+  rootPath: string,
+  limit: number,
+): Promise<{ lines: Array<string>; truncated: boolean }>
+{
+  const output: Array<string> = [];
+  const selected = matches.slice(0, limit);
+  for (const match of selected) {
+    const rangeText = `${match.range.start.line}-${match.range.end.line}`;
+    const summary = match.summary ? `\nSummary: ${match.summary}` : "";
+    const snippet = await getChunkContent(rootPath, match);
+    output.push(`\n${match.symbol} (${match.path}:${rangeText})${summary}\n---\n${snippet}`);
+  }
+  return { lines: output, truncated: matches.length > selected.length };
+}

--- a/codex-cli/src/utils/context-index/summaries.ts
+++ b/codex-cli/src/utils/context-index/summaries.ts
@@ -1,0 +1,125 @@
+import type {
+  ContextChunk,
+  SummaryGenerator,
+  SummaryGeneratorInput,
+} from "./types.js";
+
+function fallbackSummary({ chunk, content }: SummaryGeneratorInput): string {
+  const normalized = content.trim().replace(/\s+/g, " ");
+  if (!normalized) {
+    return `Context chunk for ${chunk.symbol}`;
+  }
+  return `${chunk.symbol}: ${normalized.slice(0, 180)}${
+    normalized.length > 180 ? "…" : ""
+  }`;
+}
+
+export function createDefaultSummaryGenerator(): SummaryGenerator {
+  const mode = process.env["CODEX_CONTEXT_SUMMARY_MODE"];
+  const explicitModel = process.env["CODEX_CONTEXT_SUMMARY_MODEL"];
+  let providerPromise:
+    | Promise<{ provider: any; defaultModel: string }>
+    | null = null;
+
+  async function ensureProvider(): Promise<{ provider: any; defaultModel: string }> {
+    if (!providerPromise) {
+      providerPromise = import("../get-provider.js").then(({ getModelProvider }) => {
+        const providerInstance = getModelProvider();
+        return {
+          provider: providerInstance,
+          defaultModel: providerInstance.getDefaultModel(),
+        };
+      });
+    }
+    return providerPromise;
+  }
+
+  return async (input: SummaryGeneratorInput): Promise<string> => {
+    if (mode === "mock") {
+      return fallbackSummary(input);
+    }
+
+    const { provider, defaultModel } = await ensureProvider();
+    const model = explicitModel || defaultModel;
+    try {
+      const response = await provider.createChatCompletion({
+        model,
+        messages: [
+          {
+            role: "system",
+            content:
+              "Summarize the following code snippet in one or two sentences, focusing on its intent and important details.",
+          },
+          {
+            role: "user",
+            content: `File: ${input.chunk.path}\nSymbol: ${input.chunk.symbol}\n\n${input.content}`,
+          },
+        ],
+      });
+      const trimmed = response.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Failed to generate chunk summary via provider, falling back to heuristic summary:",
+        error,
+      );
+    }
+
+    return fallbackSummary(input);
+  };
+}
+
+export class SummaryCache {
+  private cache: Record<string, string>;
+
+  private generator: SummaryGenerator;
+
+  private generatedCount = 0;
+
+  constructor(
+    initial: Record<string, string> = {},
+    generator: SummaryGenerator = createDefaultSummaryGenerator(),
+  ) {
+    this.cache = { ...initial };
+    this.generator = generator;
+  }
+
+  get(hash: string): string | undefined {
+    return this.cache[hash];
+  }
+
+  invalidate(hash: string): void {
+    delete this.cache[hash];
+  }
+
+  async ensureSummary(
+    chunk: ContextChunk,
+    content: string,
+    options: { force?: boolean } = {},
+  ): Promise<string> {
+    if (!options.force) {
+      const existing = this.cache[chunk.hash];
+      if (existing) {
+        return existing;
+      }
+    } else {
+      this.invalidate(chunk.hash);
+    }
+
+    const summary = await this.generator({ chunk, content });
+    this.cache[chunk.hash] = summary;
+    this.generatedCount += 1;
+    return summary;
+  }
+
+  getGeneratedCount(): number {
+    return this.generatedCount;
+  }
+
+  toJSON(): Record<string, string> {
+    return { ...this.cache };
+  }
+}

--- a/codex-cli/src/utils/context-index/types.ts
+++ b/codex-cli/src/utils/context-index/types.ts
@@ -1,0 +1,100 @@
+export interface ChunkPosition {
+  /** Zero-based character offset in the file. */
+  offset: number;
+  /** One-based line number for display. */
+  line: number;
+  /** One-based column number for display. */
+  column: number;
+}
+
+export interface ChunkRange {
+  start: ChunkPosition;
+  end: ChunkPosition;
+}
+
+export interface ContextChunk {
+  /** File path relative to the indexed root. */
+  path: string;
+  /** Symbol or label associated with the chunk. */
+  symbol: string;
+  /** Range within the file represented by the chunk. */
+  range: ChunkRange;
+  /** Deterministic SHA-256 hash of the chunk contents. */
+  hash: string;
+  /** Optional cached summary text. */
+  summary?: string;
+}
+
+export interface MerkleNode {
+  /** Combined hash for this node and all descendants. */
+  hash: string;
+  /** Optional chunk if this is a leaf node. */
+  chunk?: ContextChunk;
+  /** Child nodes. */
+  children: Array<MerkleNode>;
+}
+
+export interface FileIndexEntry {
+  /** Relative path for the file. */
+  path: string;
+  /** Root Merkle node representing the file. */
+  merkle: MerkleNode;
+  /** Ordered list of chunks contained in the file. */
+  chunks: Array<ContextChunk>;
+}
+
+export interface ContextIndexData {
+  /** Version for the on-disk index schema. */
+  version: number;
+  /** ISO timestamp for the last successful indexing run. */
+  generatedAt: string;
+  /** Map of relative file paths to their chunk data. */
+  files: Record<string, FileIndexEntry>;
+  /** Map of chunk hash to cached summary text. */
+  summaries: Record<string, string>;
+}
+
+export interface ChunkDescriptor {
+  symbol: string;
+  range: ChunkRange;
+}
+
+export interface Chunker {
+  /** Returns true when this chunker can process the given file path. */
+  test: (filePath: string) => boolean;
+  /** Extracts structured chunks from the file contents. */
+  extract: (filePath: string, sourceText: string) => Array<ChunkDescriptor>;
+}
+
+export interface SummaryGeneratorInput {
+  chunk: ContextChunk;
+  content: string;
+}
+
+export type SummaryGenerator = (
+  input: SummaryGeneratorInput,
+) => Promise<string>;
+
+export interface IndexStats {
+  filesProcessed: number;
+  filesUpdated: number;
+  chunksDiscovered: number;
+  summariesGenerated: number;
+}
+
+export interface IndexOptions {
+  /** Root directory that owns the .codex folder. */
+  rootPath: string;
+  /** Optional explicit directory to index (defaults to rootPath). */
+  targetPath?: string;
+  /** Optional relative or absolute file path to refresh. */
+  refreshPaths?: Array<string>;
+  /** Maximum number of characters per fallback chunk. */
+  fallbackChunkSize?: number;
+  /** Custom summary generator, primarily for testing. */
+  summaryGenerator?: SummaryGenerator;
+}
+
+export interface SearchMatch extends ContextChunk {
+  fileSummary?: string;
+}

--- a/codex-cli/tests/context-index.test.ts
+++ b/codex-cli/tests/context-index.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { typescriptChunker } from "../src/utils/context-index/chunkers/typescript.js";
+import {
+  indexContext,
+  loadContextIndex,
+  searchContextChunks,
+  type ContextIndexData,
+} from "../src/utils/context-index/index.js";
+import { formatIndexStats, formatShowMatches } from "../src/utils/context-index/renderers.js";
+import type { SummaryGenerator } from "../src/utils/context-index/types.js";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function createTempDir(prefix: string): string {
+  return mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe("context index", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir("context-index-");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("TypeScript chunker extracts AST symbols", () => {
+    const source = `export class Greeter {\n  greet(name: string) {\n    return \`Hello, \${name}\`;\n  }\n}\n\nexport function helper() {\n  return 42;\n}\n\nconst local = () => 'ok';\n`;
+
+    const descriptors = typescriptChunker.extract("sample.ts", source);
+    const symbols = descriptors.map((descriptor) => descriptor.symbol);
+
+    expect(symbols).toContain("Greeter");
+    expect(symbols).toContain("Greeter.greet");
+    expect(symbols).toContain("helper");
+    expect(symbols).toContain("local");
+
+    const greeter = descriptors.find((descriptor) => descriptor.symbol === "Greeter");
+    expect(greeter?.range.start.line).toBe(1);
+    expect(greeter?.range.end.line).toBeGreaterThanOrEqual(5);
+  });
+
+  test("indexContext reuses summaries when Merkle root is unchanged", async () => {
+    const filePath = path.join(tempDir, "module.ts");
+    await fs.writeFile(
+      filePath,
+      `export function alpha() {\n  return 1;\n}\n`,
+      "utf-8",
+    );
+
+    let summaryCalls = 0;
+    const generator: SummaryGenerator = async ({ chunk, content }) => {
+      summaryCalls += 1;
+      return `summary:${chunk.symbol}:${content.length}`;
+    };
+
+    const first = await indexContext({
+      rootPath: tempDir,
+      summaryGenerator: generator,
+    });
+    expect(first.stats.filesProcessed).toBe(1);
+    expect(first.stats.summariesGenerated).toBeGreaterThan(0);
+    expect(summaryCalls).toBe(first.stats.summariesGenerated);
+
+    summaryCalls = 0;
+    const second = await indexContext({
+      rootPath: tempDir,
+      summaryGenerator: generator,
+    });
+    expect(second.stats.filesUpdated).toBe(0);
+    expect(summaryCalls).toBe(0);
+
+    await fs.writeFile(
+      filePath,
+      `export function alpha() {\n  return 2;\n}\n`,
+      "utf-8",
+    );
+
+    summaryCalls = 0;
+    const third = await indexContext({
+      rootPath: tempDir,
+      summaryGenerator: generator,
+    });
+    expect(third.stats.filesUpdated).toBe(1);
+    expect(summaryCalls).toBeGreaterThan(0);
+  });
+
+  test("context CLI commands build and display the index", async () => {
+    const filePath = path.join(tempDir, "feature.ts");
+    await fs.writeFile(
+      filePath,
+      `export function display(value: string) {\n  return value.toUpperCase();\n}\n`,
+      "utf-8",
+    );
+
+    const generator: SummaryGenerator = async ({ chunk }) =>
+      `mock-summary:${chunk.symbol}`;
+
+    const { stats, indexPath } = await indexContext({
+      rootPath: tempDir,
+      summaryGenerator: generator,
+    });
+    const summaryLine = formatIndexStats(stats, indexPath);
+    expect(summaryLine).toContain("Indexed 1 file");
+    expect(summaryLine).toContain(indexPath);
+
+    const index: ContextIndexData | null = await loadContextIndex(tempDir);
+    expect(index).not.toBeNull();
+    const matches = index ? searchContextChunks(index, "display") : [];
+    expect(matches.length).toBeGreaterThan(0);
+
+    const { lines } = await formatShowMatches(matches, tempDir, 5);
+    expect(lines.some((line) => line.includes("display"))).toBe(true);
+    expect(lines.some((line) => line.includes("mock-summary"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add context index data structures, TypeScript chunker, fallback chunker, Merkle hashing, summary cache, and search helpers
- expose CLI context subcommands with formatting helpers and allow TerminalChat to surface indexed chunks via /context
- cover the new indexing flow with vitest fixtures that exercise chunk extraction, incremental hashing, and formatted output

## Testing
- npm test -- tests/context-index.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf828a9920832590746e89d0c7d363